### PR TITLE
update to use on Google Cloud Functions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-# Use an Ubuntu 18.04 LTS base image so that our build environment is identical
-# to most cloud servers onto which we'd be doing the deploying.
-FROM ubuntu:bionic
+# Dockerfile to build tesseract with static linking so that it can run on Firebase functions. 
+# Works on Firebase Functions (Google Cloud Functions)
+# Use a base image that matches Firebase Functions environment more closely
+FROM debian:buster-slim
 
-# Initial run of apt update
-RUN apt update
-
-# Install everything we'd need in a build environment within Docker
-RUN apt install \
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
     wget \
     git \
     build-essential \
@@ -15,45 +13,48 @@ RUN apt install \
     automake \
     libtool \
     pkg-config \
-    apt-transport-https \
-    ppa-purge \
-    zsh \
-    screen \
-    byobu \
-    parallel \
-    iperf3 \
-    iotop \
-    atop \
-    nethogs \
-    htop \
-    software-properties-common \
-    -y
-
-################################################################################
-###### Everything above this line can be part of a ubuntu-build base image #####
-################################################################################
-
-# Install Dependencies for the software we wish to compile
-RUN apt install \
     libicu-dev \
     libpango1.0-dev \
     libcairo2-dev \
     libleptonica-dev \
-    -y
+    libpng-dev \
+    libjpeg62-turbo-dev \
+    libtiff5-dev \
+    zlib1g-dev
 
-# Download software and extract to a working directory
+# Download and build Leptonica statically
+RUN wget http://www.leptonica.org/source/leptonica-1.80.0.tar.gz && \
+    tar -xzvf leptonica-1.80.0.tar.gz && \
+    cd leptonica-1.80.0 && \
+    ./configure --enable-static --disable-shared && \
+    make && \
+    make install
+
+# Download Tesseract source
 ADD https://github.com/tesseract-ocr/tesseract/archive/4.1.0.tar.gz /
 RUN tar -xf 4.1.0.tar.gz
 
-# Switch to this working directory
+# Build Tesseract with static linking
 WORKDIR /tesseract-4.1.0
+RUN ./autogen.sh && \
+    LIBLEPT_HEADERSDIR=/usr/local/include ./configure \
+    --enable-static \
+    --disable-shared \
+    --with-extra-libraries=/usr/local/lib && \
+    LDFLAGS="-static" make && \
+    make install
 
-# Run build commands
-RUN ./autogen.sh \
-    && ./configure --disable-shared \
-    && make \
-    && make install \
-    && cp `which tesseract` .
+# Copy the built binary and necessary data
+RUN mkdir -p /app/bin /app/share && \
+    cp /usr/local/bin/tesseract /app/bin/tesseract && \
+    cp -r /usr/local/share/tessdata /app/share/
+
+# Use a minimal base image for the final stage
+FROM scratch
+COPY --from=0 /app /app
+
+# Set up environment variables
+ENV TESSDATA_PREFIX=/app/share/tessdata
 
 # This ensures the container never stops
 CMD ["sleep", "infinity"]

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,18 @@
 #!/bin/sh
 echo 'Deleting tesseract binary from current folder...'
 rm ./tesseract
-echo 'Bringing up Docker Container...'
-docker-compose up -d
+
+echo 'Building Docker image for x86_64 architecture...'
+docker buildx build --platform linux/amd64 -t tesseract-static-builder .
+
+echo 'Creating temporary container...'
+docker create --name temp tesseract-static-builder
+
 echo 'Copying Built Tesseract Binary...'
-docker cp `docker-compose ps -q tesseract`:/tesseract-4.1.0/tesseract .
-echo 'Killing Container...'
-docker-compose kill
-echo 'Taking Container Down...'
-docker-compose down
+docker cp temp:/app/bin/tesseract ./tesseract
+
+echo 'Removing temporary container...'
+docker rm temp
+
 echo 'Done building static Tesseract binary!'
-echo 'Copy the "tesseract" executable from this folder to wherever you want it!'
+echo 'The "tesseract" executable is now in the current folder.'


### PR DESCRIPTION
I tested it and it runs in my Firebase Function

```
andrew@Andrews-Mini static-tesseract-master % ./build.sh              
Deleting tesseract binary from current folder...
Building Docker image for x86_64 architecture...
[+] Building 997.8s (14/14) FINISHED                                                                 docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                 0.0s
 => => transferring dockerfile: 1.75kB                                                                               0.0s
 => [internal] load metadata for docker.io/library/debian:buster-slim                                                0.9s
 => [internal] load .dockerignore                                                                                    0.0s
 => => transferring context: 2B                                                                                      0.0s
 => [stage-0 1/8] FROM docker.io/library/debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b  0.9s
 => => resolve docker.io/library/debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b  0.0s
 => => sha256:b338562f40a7fb7360dfae935da6d7e40d2545db18bc461d9d70ec1b2b657f33 27.34MB / 27.34MB                     0.5s
 => => extracting sha256:b338562f40a7fb7360dfae935da6d7e40d2545db18bc461d9d70ec1b2b657f33                            0.4s
 => [stage-0 4/8] ADD https://github.com/tesseract-ocr/tesseract/archive/4.1.0.tar.gz /                              0.7s
 => [stage-0 2/8] RUN apt-get update && apt-get install -y     wget     git     build-essential     curl     autoc  67.3s
 => [stage-0 3/8] RUN wget http://www.leptonica.org/source/leptonica-1.80.0.tar.gz &&     tar -xzvf leptonica-1.8  486.4s 
 => [stage-0 4/8] ADD https://github.com/tesseract-ocr/tesseract/archive/4.1.0.tar.gz /                              0.0s 
 => [stage-0 5/8] RUN tar -xf 4.1.0.tar.gz                                                                           0.3s 
 => [stage-0 6/8] WORKDIR /tesseract-4.1.0                                                                           0.0s 
 => [stage-0 7/8] RUN ./autogen.sh &&     LIBLEPT_HEADERSDIR=/usr/local/include ./configure     --enable-static    439.9s 
 => [stage-0 8/8] RUN mkdir -p /app/bin /app/share &&     cp /usr/local/bin/tesseract /app/bin/tesseract &&     cp   0.3s 
 => [stage-1 1/1] COPY --from=0 /app /app                                                                            0.0s 
 => exporting to image                                                                                               1.5s 
 => => exporting layers                                                                                              1.5s 
 => => exporting manifest sha256:9d8dc44d9aea9678c9be7ad9f5ed1606c6bfac512ac9bbcb9b2cdc229c767e34                    0.0s 
 => => exporting config sha256:532b99ebe577011f6d143fbb08345bf0aaaba1823544dc8badfd340c07958571                      0.0s 
 => => exporting attestation manifest sha256:361f4e0389f4ddcff82039cacb9683de4d9c487fafaf7182b2bec77166e32e35        0.0s
 => => exporting manifest list sha256:ace7f132bb4594a084045435b1905a4cf2e3b6a041acad75af4cef30481b532e               0.0s
 => => naming to docker.io/library/tesseract-static-builder:latest                                                   0.0s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/fb16bej3i1eydy7gj6c2ldbtz
Creating temporary container...
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
1661e264bd2bc4a7f87264784d23e518e30f75a1dd0c32970b1485adb1f9d816
Copying Built Tesseract Binary...
Successfully copied 55.6MB to /Users/andrew/Downloads/static-tesseract-master/tesseract
Removing temporary container...
temp
Done building static Tesseract binary!
The "tesseract" executable is now in the current folder.
```